### PR TITLE
Unref timeout to prevent timer from allowing graceful shutdown.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = function timeout(ms) {
     var id = setTimeout(function(){
       req.emit('timeout', ms);
     }, ms);
+	id.unref();
 
     req.on('timeout', function(){
       if (res.headersSent) return debug('response started, cannot timeout');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-timeout",
   "description": "timeout middleware",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Jonathan Ong",
     "email": "me@jongleberry.com",


### PR DESCRIPTION
See http://nodejs.org/api/timers.html#timers_unref
