### PR TITLE
add functions to change timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ the response behavior. This error has a `.timeout` property as well as
 Clears the timeout on the request. The timeout is completely removed and
 will not fire for this request in the future.
 
+### req.resetTimeout(time)
+
+Resets the timeout on the request. The timeout is reset to the `time` given.
+
+### req.addTimeout(time)
+
+Adds to the timeout on the request. The timeout is increased by the `time` given.
+
+### req.getTimeout()
+
+Get the current timeout remaining (in milliseconds).
+
 ### req.timedout
 
 `true` if timeout fired; `false` otherwise.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Get the current timeout remaining (in milliseconds).
 
 ### req.timedout
 
-`true` if timeout fired; `false` otherwise.
+`true` if timeout fired; `false` otherwise. This will remain `true` if the timeout was changed after timeout was fired.
 
 ## Examples
 

--- a/index.js
+++ b/index.js
@@ -75,8 +75,12 @@ function timeout (time, options) {
       moreDelay = typeof moreDelay === 'string'
         ? ms(moreDelay)
         : Number(moreDelay)
-      var actualDelay = req.timeoutLeft() + moreDelay
+      var timeLeft = req.timeoutLeft()
+      var actualDelay = timeLeft + moreDelay
       delay = delay + moreDelay
+      if (timeLeft === 0) {
+        started = Date.now() + actualDelay - delay
+      }
       clearTimeout(id)
       id = createTimeout(req, actualDelay)
     }

--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ function timeout (time, options) {
     }
 
     req.setTimeout = function (newDelay) {
+      newDelay = typeof newDelay === 'string'
+        ? ms(newDelay)
+        : Number(newDelay)
       started = Date.now()
       delay = newDelay
       clearTimeout(id)
@@ -68,6 +71,9 @@ function timeout (time, options) {
     }
 
     req.addTimeout = function (moreDelay) {
+      moreDelay = typeof moreDelay === 'string'
+        ? ms(moreDelay)
+        : Number(moreDelay)
       var actualDelay = req.timeoutLeft() + moreDelay
       delay = delay + moreDelay
       clearTimeout(id)

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ function timeout (time, options) {
     }
 
     req.clearTimeout = function () {
+      delay = 0
       clearTimeout(id)
     }
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function timeout (time, options) {
     req.resetTimeout = function (newDelay) {
       newDelay = typeof newDelay === 'string'
         ? ms(newDelay)
-        : Number(newDelay)
+        : Number(newDelay || 5000)
       started = Date.now()
       delay = newDelay
       clearTimeout(id)
@@ -74,7 +74,7 @@ function timeout (time, options) {
     req.addTimeout = function (moreDelay) {
       moreDelay = typeof moreDelay === 'string'
         ? ms(moreDelay)
-        : Number(moreDelay)
+        : Number(moreDelay || 5000)
       var timeLeft = req.getTimeout()
       var actualDelay = timeLeft + moreDelay
       delay = delay + moreDelay

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function timeout (time, options) {
       clearTimeout(id)
     }
 
-    req.setTimeout = function (newDelay) {
+    req.resetTimeout = function (newDelay) {
       newDelay = typeof newDelay === 'string'
         ? ms(newDelay)
         : Number(newDelay)
@@ -75,7 +75,7 @@ function timeout (time, options) {
       moreDelay = typeof moreDelay === 'string'
         ? ms(moreDelay)
         : Number(moreDelay)
-      var timeLeft = req.timeoutLeft()
+      var timeLeft = req.getTimeout()
       var actualDelay = timeLeft + moreDelay
       delay = delay + moreDelay
       if (timeLeft === 0) {
@@ -85,7 +85,7 @@ function timeout (time, options) {
       id = createTimeout(req, actualDelay)
     }
 
-    req.timeoutLeft = function () {
+    req.getTimeout = function () {
       var time = delay - (Date.now() - started)
       return (time > 0 ? time : 0)
     }

--- a/test/test.js
+++ b/test/test.js
@@ -106,6 +106,76 @@ describe('timeout()', function () {
     })
   })
 
+  describe('req.setTimeout()', function () {
+    it('should reset the timeout', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.setTimeout(1000) },
+        function (req, res) {
+          assert.ok(!req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
+    })
+    it('should still timeout after the new timeout', function (done) {
+      var server = createServer(null,
+        function (req, res) { setTimeout(function () { req.setTimeout(120) }, 50) },
+        function (req, res) {
+          assert.ok(req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(503, 'Response timeout after 120ms', done)
+    })
+  })
+
+  describe('req.addTimeout()', function () {
+    it('should reset the timeout', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.addTimeout(1000) },
+        function (req, res) {
+          assert.ok(!req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
+    })
+    it('should still timeout after the new timeout', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.addTimeout(90) },
+        function (req, res) {
+          assert.ok(req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(503, 'Response timeout after 190ms', done)
+    })
+  })
+
+  describe('req.timeoutLeft()', function () {
+    it('should get the correct timeout left', function (done) {
+      var server = createServer(null,
+        function (req, res) { setTimeout(function () { assert.ok(req.timeoutLeft() > 0 && req.timeoutLeft() < 100) }, 50) },
+        function (req, res) {
+          assert.equal(req.timeoutLeft(), 0)
+          res.end('Hello')
+          done()
+        })
+
+      request(server)
+      .get('/')
+      .expect(503, 'Response timeout after 100ms', function () {})
+    })
+  })
+
   describe('destroy()', function () {
     it('req should clear timer', function (done) {
       var server = createServer(null,

--- a/test/test.js
+++ b/test/test.js
@@ -106,10 +106,10 @@ describe('timeout()', function () {
     })
   })
 
-  describe('req.setTimeout()', function () {
+  describe('req.resetTimeout()', function () {
     it('should reset the timeout', function (done) {
       var server = createServer(null,
-        function (req, res) { req.setTimeout(1000) },
+        function (req, res) { req.resetTimeout(1000) },
         function (req, res) {
           assert.ok(!req.timedout)
           res.end('Hello')
@@ -121,7 +121,7 @@ describe('timeout()', function () {
     })
     it('should reset the timeout with a string', function (done) {
       var server = createServer(null,
-        function (req, res) { req.setTimeout('1s') },
+        function (req, res) { req.resetTimeout('1s') },
         function (req, res) {
           assert.ok(!req.timedout)
           res.end('Hello')
@@ -133,7 +133,7 @@ describe('timeout()', function () {
     })
     it('should still timeout after the new timeout', function (done) {
       var server = createServer(null,
-        function (req, res) { setTimeout(function () { req.setTimeout(120) }, 50) },
+        function (req, res) { setTimeout(function () { req.resetTimeout(120) }, 50) },
         function (req, res) {
           assert.ok(req.timedout)
           res.end('Hello')
@@ -187,9 +187,9 @@ describe('timeout()', function () {
         function (req, res) {
           req.clearTimeout()
           setTimeout(function () {
-            assert.equal(req.timeoutLeft(), 0)
+            assert.equal(req.getTimeout(), 0)
             req.addTimeout(10)
-            assert.ok(req.timeoutLeft() > 0 && req.timeoutLeft() <= 10)
+            assert.ok(req.getTimeout() > 0 && req.getTimeout() <= 10)
           }, 50)
         },
         function (req, res) {
@@ -203,16 +203,16 @@ describe('timeout()', function () {
     })
   })
 
-  describe('req.timeoutLeft()', function () {
+  describe('req.getTimeout()', function () {
     it('should get the correct timeout left', function (done) {
       var server = createServer(null,
         function (req, res) {
           setTimeout(function () {
-            assert.ok(req.timeoutLeft() > 0 && req.timeoutLeft() < 100)
+            assert.ok(req.getTimeout() > 0 && req.getTimeout() < 100)
           }, 50)
         },
         function (req, res) {
-          assert.equal(req.timeoutLeft(), 0)
+          assert.equal(req.getTimeout(), 0)
           res.end('Hello')
           done()
         })
@@ -224,9 +224,9 @@ describe('timeout()', function () {
     it('should return 0 after clearTimeout', function (done) {
       var server = createServer(null,
         function (req, res) {
-          assert.ok(req.timeoutLeft() > 0)
+          assert.ok(req.getTimeout() > 0)
           req.clearTimeout()
-          assert.equal(req.timeoutLeft(), 0)
+          assert.equal(req.getTimeout(), 0)
         },
         function (req, res) {
           res.end('Hello')

--- a/test/test.js
+++ b/test/test.js
@@ -187,7 +187,11 @@ describe('timeout()', function () {
   describe('req.timeoutLeft()', function () {
     it('should get the correct timeout left', function (done) {
       var server = createServer(null,
-        function (req, res) { setTimeout(function () { assert.ok(req.timeoutLeft() > 0 && req.timeoutLeft() < 100) }, 50) },
+        function (req, res) {
+          setTimeout(function () {
+            assert.ok(req.timeoutLeft() > 0 && req.timeoutLeft() < 100)
+          }, 50)
+        },
         function (req, res) {
           assert.equal(req.timeoutLeft(), 0)
           res.end('Hello')
@@ -197,6 +201,21 @@ describe('timeout()', function () {
       request(server)
       .get('/')
       .expect(503, 'Response timeout after 100ms', function () {})
+    })
+    it('should return 0 after clearTimeout', function (done) {
+      var server = createServer(null,
+        function (req, res) {
+          assert.ok(req.timeoutLeft() > 0)
+          req.clearTimeout()
+          assert.equal(req.timeoutLeft(), 0)
+        },
+        function (req, res) {
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -182,6 +182,25 @@ describe('timeout()', function () {
       .get('/')
       .expect(503, 'Response timeout after 190ms', done)
     })
+    it('should reset timeLeft if cleared', function (done) {
+      var server = createServer(null,
+        function (req, res) {
+          req.clearTimeout()
+          setTimeout(function () {
+            assert.equal(req.timeoutLeft(), 0)
+            req.addTimeout(10)
+            assert.ok(req.timeoutLeft() > 0 && req.timeoutLeft() <= 10)
+          }, 50)
+        },
+        function (req, res) {
+          assert.ok(req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(503, 'Response timeout after 10ms', done)
+    })
   })
 
   describe('req.timeoutLeft()', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -112,36 +112,46 @@ describe('timeout()', function () {
         function (req, res) { req.resetTimeout(1000) },
         function (req, res) {
           assert.ok(!req.timedout)
-          res.end('Hello')
+          setTimeout(function () {
+            assert.ok(req.timedout)
+            res.end('Hello')
+          }, 1000)
         })
 
       request(server)
       .get('/')
-      .expect(200, 'Hello', done)
+      .expect(503, /1000ms/, done)
     })
     it('should reset the timeout with a string', function (done) {
       var server = createServer(null,
         function (req, res) { req.resetTimeout('1s') },
         function (req, res) {
           assert.ok(!req.timedout)
-          res.end('Hello')
+          setTimeout(function () {
+            assert.ok(req.timedout)
+            res.end('Hello')
+          }, 1000)
         })
 
       request(server)
       .get('/')
-      .expect(200, 'Hello', done)
+      .expect(503, /1000ms/, done)
     })
     it('should reset the timeout with 5000 default', function (done) {
+      this.timeout(10000)
       var server = createServer(null,
         function (req, res) { req.resetTimeout() },
         function (req, res) {
           assert.ok(!req.timedout)
-          res.end('Hello')
+          setTimeout(function () {
+            assert.ok(req.timedout)
+            res.end('Hello')
+          }, 5000)
         })
 
       request(server)
       .get('/')
-      .expect(200, 'Hello', done)
+      .expect(503, /5000ms/, done)
     })
     it('should still timeout after the new timeout', function (done) {
       var server = createServer(null,
@@ -153,7 +163,7 @@ describe('timeout()', function () {
 
       request(server)
       .get('/')
-      .expect(503, 'Response timeout after 120ms', done)
+      .expect(503, /120ms/, done)
     })
   })
 
@@ -163,36 +173,46 @@ describe('timeout()', function () {
         function (req, res) { req.addTimeout(1000) },
         function (req, res) {
           assert.ok(!req.timedout)
-          res.end('Hello')
+          setTimeout(function () {
+            assert.ok(req.timedout)
+            res.end('Hello')
+          }, 1000)
         })
 
       request(server)
       .get('/')
-      .expect(200, 'Hello', done)
+      .expect(503, /1100ms/, done)
     })
     it('should reset the timeout with a string', function (done) {
       var server = createServer(null,
         function (req, res) { req.addTimeout('1s') },
         function (req, res) {
           assert.ok(!req.timedout)
-          res.end('Hello')
+          setTimeout(function () {
+            assert.ok(req.timedout)
+            res.end('Hello')
+          }, 1000)
         })
 
       request(server)
       .get('/')
-      .expect(200, 'Hello', done)
+      .expect(503, /1100ms/, done)
     })
     it('should reset the timeout with 5000 default', function (done) {
+      this.timeout(10000)
       var server = createServer(null,
         function (req, res) { req.addTimeout() },
         function (req, res) {
           assert.ok(!req.timedout)
-          res.end('Hello')
+          setTimeout(function () {
+            assert.ok(req.timedout)
+            res.end('Hello')
+          }, 5000)
         })
 
       request(server)
       .get('/')
-      .expect(200, 'Hello', done)
+      .expect(503, /5100ms/, done)
     })
     it('should still timeout after the new timeout', function (done) {
       var server = createServer(null,
@@ -204,7 +224,7 @@ describe('timeout()', function () {
 
       request(server)
       .get('/')
-      .expect(503, 'Response timeout after 190ms', done)
+      .expect(503, /190ms/, done)
     })
     it('should reset timeLeft if cleared', function (done) {
       var server = createServer(null,
@@ -223,7 +243,7 @@ describe('timeout()', function () {
 
       request(server)
       .get('/')
-      .expect(503, 'Response timeout after 10ms', done)
+      .expect(503, /10ms/, done)
     })
   })
 
@@ -243,7 +263,7 @@ describe('timeout()', function () {
 
       request(server)
       .get('/')
-      .expect(503, 'Response timeout after 100ms', function () {})
+      .expect(503, /100ms/, function () {})
     })
     it('should return 0 after clearTimeout', function (done) {
       var server = createServer(null,

--- a/test/test.js
+++ b/test/test.js
@@ -119,6 +119,18 @@ describe('timeout()', function () {
       .get('/')
       .expect(200, 'Hello', done)
     })
+    it('should reset the timeout with a string', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.setTimeout('1s') },
+        function (req, res) {
+          assert.ok(!req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
+    })
     it('should still timeout after the new timeout', function (done) {
       var server = createServer(null,
         function (req, res) { setTimeout(function () { req.setTimeout(120) }, 50) },
@@ -137,6 +149,18 @@ describe('timeout()', function () {
     it('should reset the timeout', function (done) {
       var server = createServer(null,
         function (req, res) { req.addTimeout(1000) },
+        function (req, res) {
+          assert.ok(!req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
+    })
+    it('should reset the timeout with a string', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.addTimeout('1s') },
         function (req, res) {
           assert.ok(!req.timedout)
           res.end('Hello')

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,18 @@ describe('timeout()', function () {
       .get('/')
       .expect(200, 'Hello', done)
     })
+    it('should reset the timeout with 5000 default', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.resetTimeout() },
+        function (req, res) {
+          assert.ok(!req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
+    })
     it('should still timeout after the new timeout', function (done) {
       var server = createServer(null,
         function (req, res) { setTimeout(function () { req.resetTimeout(120) }, 50) },
@@ -161,6 +173,18 @@ describe('timeout()', function () {
     it('should reset the timeout with a string', function (done) {
       var server = createServer(null,
         function (req, res) { req.addTimeout('1s') },
+        function (req, res) {
+          assert.ok(!req.timedout)
+          res.end('Hello')
+        })
+
+      request(server)
+      .get('/')
+      .expect(200, 'Hello', done)
+    })
+    it('should reset the timeout with 5000 default', function (done) {
+      var server = createServer(null,
+        function (req, res) { req.addTimeout() },
         function (req, res) {
           assert.ok(!req.timedout)
           res.end('Hello')


### PR DESCRIPTION
add functions to `req` to change timeout

`req.resetTimeout(delay)`: reset the timeout and start from now
`req.addTimeout(delay)`: add to the current timeout
`req.getTimeout()`: get the amount of milliseconds left (0 after timedout)

fixes #26