### PR TITLE
Remove convert timeout to number type in case typeof not string

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function timeout (time, options) {
 
   var delay = typeof time === 'string'
     ? ms(time)
-    : Number(time || 5000)
+    : time || 5000
 
   var respond = opts.respond === undefined || opts.respond === true
 


### PR DESCRIPTION
There are two tests which already cover this code base:
'should accept millisecond timeout'
'should accept string timeout'
Both passed - ok.
